### PR TITLE
Hug plugin

### DIFF
--- a/basement_bot/plugins/hug.py
+++ b/basement_bot/plugins/hug.py
@@ -9,7 +9,7 @@ def setup(bot):
 async def hug(ctx):
     try:
         if not ctx.message.mentions:
-            await ctx.send(f"You hugging the air?")
+            await ctx.send(f"{ctx.author.mention} You hugging the air?")
             return
         
         has_author_mentioned = False

--- a/basement_bot/plugins/hug.py
+++ b/basement_bot/plugins/hug.py
@@ -19,15 +19,15 @@ async def hug(ctx):
                 has_author_mentioned = True
             elif user.bot:
                 has_bot_mentioned = True
-                
+
         if has_author_mentioned and has_bot_mentioned:
-            await ctx.send(f"You're tyring to hug the bot AND yourself? You got issues")
+            await ctx.send(f"{ctx.author.mention} You're tyring to hug the bot AND yourself? You got issues")
             return
         elif has_author_mentioned:
-            await ctx.send(f"You tried to hug yourself?")
+            await ctx.send(f"{ctx.author.mention} You tried to hug yourself?")
             return
         elif has_bot_mentioned:
-            await ctx.send(f"You tried to hug the bot?")
+            await ctx.send(f"{ctx.author.mention} You tried to hug the bot?")
             return
 
         if len(ctx.message.mentions) > 1:
@@ -48,5 +48,5 @@ hugs = [
     "{user_giving_hug} reluctantly hugs {user_to_hug}...",
     "{user_giving_hug} hugs {user_to_hug} into a coma",
     "{user_giving_hug} smothers {user_to_hug} with a loving hug",
-    "{user_giving_hug} squeezes {user_to_hug} to death",
+    "{user_giving_hug} squeezes {user_to_hug} to death"
 ]

--- a/basement_bot/plugins/hug.py
+++ b/basement_bot/plugins/hug.py
@@ -1,0 +1,52 @@
+from random import choice
+from discord.ext import commands
+from utils import tagged_response
+
+def setup(bot):
+    bot.add_command(hug)
+
+@commands.command(name="hug")
+async def hug(ctx):
+    try:
+        if not ctx.message.mentions:
+            await ctx.send(f"You hugging the air?")
+            return
+        
+        has_author_mentioned = False
+        has_bot_mentioned = False
+        for user in ctx.message.mentions:
+            if user.id == ctx.author.id:
+                has_author_mentioned = True
+            elif user.bot:
+                has_bot_mentioned = True
+                
+        if has_author_mentioned and has_bot_mentioned:
+            await ctx.send(f"You're tyring to hug the bot AND yourself? You got issues")
+            return
+        elif has_author_mentioned:
+            await ctx.send(f"You tried to hug yourself?")
+            return
+        elif has_bot_mentioned:
+            await ctx.send(f"You tried to hug the bot?")
+            return
+
+        if len(ctx.message.mentions) > 1:
+            mentions = [m.mention for m in ctx.message.mentions]
+            await ctx.send(choice(hugs).format(user_giving_hug=ctx.author.mention, user_to_hug=", ".join(mentions[:-1]) + ", and " + mentions[-1]))
+            return
+            
+        await ctx.send(choice(hugs).format(user_giving_hug=ctx.author.mention, user_to_hug=ctx.message.mentions[0].mention))
+    except:
+        await ctx.send(f"I don't know what the fuck you're trying to do!")
+
+hugs = [
+    "{user_giving_hug} hugs {user_to_hug} forever and ever and ever",
+    "{user_giving_hug} wraps arms around {user_to_hug} and clings forever",
+    "{user_giving_hug} hugs {user_to_hug} and gives their hair a sniff",
+    "{user_giving_hug} glomps {user_to_hug}",
+    "cant stop, wont stop. {user_giving_hug} hugs {user_to_hug} until the sun goes cold",
+    "{user_giving_hug} reluctantly hugs {user_to_hug}...",
+    "{user_giving_hug} hugs {user_to_hug} into a coma",
+    "{user_giving_hug} smothers {user_to_hug} with a loving hug",
+    "{user_giving_hug} squeezes {user_to_hug} to death",
+]

--- a/default.env
+++ b/default.env
@@ -1,6 +1,5 @@
 # required settings
 COMMAND_PREFIX=.
-DEBUG=0
 AUTH_TOKEN=
 
 # optional settings


### PR DESCRIPTION
Hug plugin allows for using the command '.hug' to hug a mentioned user. There are different 9 different hug messages listed that the bot can "randomly" choose from to respond with. There are six checks done on the context that give six different kinds of responses. They are as follows in the order the context is checked:
1. No users mentioned. This includes mentioning the channel with @here and just plain text after the command. Responds mentioning the author with a message.
2. List of mentioned users contains bot and author. Responds mentioning the author with a message.
3. List of mentioned users contains author. Responds mentioning the author with a message.
4. List of mentioned users contains bot. Responds mentioning the author with a message.
5. Number of mentioned users is greater than 1. Responds mentioning the author and all listed users with "randomly" chosen hug message.
6. Number of mentioned users is 1. Responds mentioning the author and the mentioned user with "randomly" chosen hug message.

Anytime the command fails and an exception is thrown, the bot responds with an error message.