### PR TITLE
Hug plugin

### DIFF
--- a/basement_bot/plugins/hug.py
+++ b/basement_bot/plugins/hug.py
@@ -1,0 +1,66 @@
+"""Module for the hug plugin
+"""
+
+from random import choice
+
+from discord.ext import commands
+
+from utils import tagged_response
+
+
+def setup(bot):
+    """Adds the hug command to the list of bot commands
+
+    parameters:
+        bot (BasementBot): the bot object to add the command to
+    """
+    bot.add_command(hug)
+
+
+@commands.command(name="hug")
+async def hug(ctx):
+    """Hugs mentioned users
+
+    usage:
+        .hug [mentioned-users]
+    """
+    try:
+        if not ctx.message.mentions:
+            await tagged_response(ctx, "You hugging the air?")
+            return
+
+        if ctx.author in ctx.message.mentions:
+            await tagged_response(ctx, "You tried to hug yourself? You got issues")
+            return
+
+        if len(ctx.message.mentions) > 1:
+            mentions = [m.mention for m in ctx.message.mentions]
+            await ctx.send(
+                choice(hugs).format(
+                    user_giving_hug=ctx.author.mention,
+                    user_to_hug=", ".join(mentions[:-1]) + ", and " + mentions[-1],
+                )
+            )
+            return
+
+        await ctx.send(
+            choice(hugs).format(
+                user_giving_hug=ctx.author.mention,
+                user_to_hug=ctx.message.mentions[0].mention,
+            )
+        )
+    except:
+        await ctx.send(f"I don't know what the fuck you're trying to do!")
+
+
+hugs = [
+    "{user_giving_hug} hugs {user_to_hug} forever and ever and ever",
+    "{user_giving_hug} wraps arms around {user_to_hug} and clings forever",
+    "{user_giving_hug} hugs {user_to_hug} and gives their hair a sniff",
+    "{user_giving_hug} glomps {user_to_hug}",
+    "cant stop, wont stop. {user_giving_hug} hugs {user_to_hug} until the sun goes cold",
+    "{user_giving_hug} reluctantly hugs {user_to_hug}...",
+    "{user_giving_hug} hugs {user_to_hug} into a coma",
+    "{user_giving_hug} smothers {user_to_hug} with a loving hug",
+    "{user_giving_hug} squeezes {user_to_hug} to death",
+]


### PR DESCRIPTION
Hug plugin allows for using the command '.hug' to hug a mentioned user. There are different 9 different hug messages listed that the bot can "randomly" choose from to respond with. There are six checks done on the context that give six different kinds of responses. They are as follows in the order the context is checked:
1. No users mentioned. This includes mentioning the channel with @here or @everyone and just plain text after the command. Responds mentioning the author with a message.
2. List of mentioned users contains bot and author. Responds mentioning the author with a message.
3. List of mentioned users contains author. Responds mentioning the author with a message.
4. List of mentioned users contains bot. Responds mentioning the author with a message.
5. Number of mentioned users is greater than 1. Responds mentioning the author and all listed users with "randomly" chosen hug message.
6. Number of mentioned users is 1. Responds mentioning the author and the mentioned user with "randomly" chosen hug message.

Anytime the command fails and an exception is thrown, the bot responds with an error message.

This is to resolve issue #11.