### PR TITLE
Command to make Github issue

### DIFF
--- a/basement_bot/admin.py
+++ b/basement_bot/admin.py
@@ -1,10 +1,10 @@
 """Cog for controlling the bot.
 """
 
+import json
 import sys
 
 import base
-import json
 import decorate
 import discord
 from discord.ext import commands
@@ -305,12 +305,9 @@ class AdminControl(base.BaseCog):
         embed.set_thumbnail(url=self.bot.user.avatar_url)
 
         await self.bot.tagged_response(ctx, embed=embed)
-    
+
     @decorate.with_typing
-    @commands.command(
-        name="issue",
-        aliases=["ish", "botish", "botissue"]
-    )
+    @commands.command(name="issue", aliases=["ish", "botish", "botissue"])
     async def issue(self, ctx, title: str, description: str):
         """Creates an issue in the bot's Github Repo
 
@@ -328,13 +325,15 @@ class AdminControl(base.BaseCog):
 
         oauth_token = self.bot.config.main.api_keys.github
         if not oauth_token:
-            await self.bot.tagged_response(ctx, "I couldn't authenticate with Github", target=ctx.author)
+            await self.bot.tagged_response(
+                ctx, "I couldn't authenticate with Github", target=ctx.author
+            )
             return
 
         headers = {
             "Authorization": f"Bearer {oauth_token}",
             "Accept": "application/vnd.github.v3+json",
-            "Content-Type": "text/plain"
+            "Content-Type": "text/plain",
         }
 
         data = {"title": f"{title}", "body": f"{description}"}
@@ -342,7 +341,9 @@ class AdminControl(base.BaseCog):
         username = self.bot.config.special.github.username
         repo = self.bot.config.special.github.repo
         if not username or not repo:
-            await self.bot.tagged_response(ctx, "I couldn't find the repository", target=ctx.author)
+            await self.bot.tagged_response(
+                ctx, "I couldn't find the repository", target=ctx.author
+            )
             return
         route = f"/repos/{username}/{repo}/issues"
 
@@ -354,7 +355,11 @@ class AdminControl(base.BaseCog):
         )
 
         if response.get("status_code") != 201:
-            await self.bot.tagged_response(ctx, "I was unable to create your issue. Please try again later.", target=ctx.author)
+            await self.bot.tagged_response(
+                ctx,
+                "I was unable to create your issue. Please try again later.",
+                target=ctx.author,
+            )
             return
 
         issueUrl = response.get("html_url")

--- a/basement_bot/admin.py
+++ b/basement_bot/admin.py
@@ -4,6 +4,7 @@
 import sys
 
 import base
+import json
 import decorate
 import discord
 from discord.ext import commands
@@ -304,3 +305,63 @@ class AdminControl(base.BaseCog):
         embed.set_thumbnail(url=self.bot.user.avatar_url)
 
         await self.bot.tagged_response(ctx, embed=embed)
+    
+    @decorate.with_typing
+    @commands.command(
+        name="issue",
+        aliases=["ish", "botish", "botissue"]
+    )
+    async def issue(self, ctx, title: str, description: str):
+        """Creates an issue in the bot's Github Repo
+
+        This is a command and should be accessed via Discord.
+
+        parameters:
+            ctx (discord.ext.Context): the context object for the calling message
+            title: the title of the issue
+            description: the description of the issue
+        """
+        GITHUB_API_BASE_URL = "https://api.github.com"
+        ICON_URL = (
+            "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+        )
+
+        oauth_token = self.bot.config.main.api_keys.github
+        if not oauth_token:
+            await self.bot.tagged_response(ctx, "I couldn't authenticate with Github", target=ctx.author)
+            return
+
+        headers = {
+            "Authorization": f"Bearer {oauth_token}",
+            "Accept": "application/vnd.github.v3+json",
+            "Content-Type": "text/plain"
+        }
+
+        data = {"title": f"{title}", "body": f"{description}"}
+
+        username = self.bot.config.special.github.username
+        repo = self.bot.config.special.github.repo
+        if not username or not repo:
+            await self.bot.tagged_response(ctx, "I couldn't find the repository", target=ctx.author)
+            return
+        route = f"/repos/{username}/{repo}/issues"
+
+        response = await self.bot.http_call(
+            "post",
+            GITHUB_API_BASE_URL + route,
+            headers=headers,
+            data=json.dumps(data),
+        )
+
+        if response.get("status_code") != 201:
+            await self.bot.tagged_response(ctx, "I was unable to create your issue. Please try again later.", target=ctx.author)
+            return
+
+        issueUrl = response.get("html_url")
+        number = response.get("number")
+
+        embed = self.bot.embed_api.Embed(title="Issue Created")
+        embed.add_field(name=f"Issue #{number}", value=f"{issueUrl}")
+        embed.set_thumbnail(url=ICON_URL)
+
+        await self.bot.tagged_response(ctx, embed=embed, target=ctx.author)

--- a/basement_bot/admin.py
+++ b/basement_bot/admin.py
@@ -321,7 +321,7 @@ class AdminControl(base.BaseCog):
             description: the description of the issue
         """
 
-        ICON_URL = (
+        icon_url = (
             "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
         )
 
@@ -343,6 +343,7 @@ class AdminControl(base.BaseCog):
         if not username or not repo:
             await self.bot.tagged_response(ctx, "I couldn't find the repository")
             return
+
         route = f"{self.GITHUB_API_BASE_URL}/repos/{username}/{repo}/issues"
 
         response = await self.bot.http_call(
@@ -363,6 +364,6 @@ class AdminControl(base.BaseCog):
 
         embed = self.bot.embed_api.Embed(title="Issue Created")
         embed.add_field(name=f"Issue #{number}", value=f"{issue_url}")
-        embed.set_thumbnail(url=ICON_URL)
+        embed.set_thumbnail(url=icon_url)
 
         await self.bot.tagged_response(ctx, embed=embed)

--- a/basement_bot/bot.py
+++ b/basement_bot/bot.py
@@ -909,7 +909,7 @@ class BasementBot(commands.Bot):
         method_fn = getattr(client, method.lower(), None)
         if not method_fn:
             raise AttributeError(f"Unable to use HTTP method: {method}")
-        
+
         get_raw_response = kwargs.pop("get_raw_response", False)
 
         await self.logger.debug(f"Making HTTP {method.upper()} request to {url}")

--- a/basement_bot/bot.py
+++ b/basement_bot/bot.py
@@ -909,7 +909,7 @@ class BasementBot(commands.Bot):
         method_fn = getattr(client, method.lower(), None)
         if not method_fn:
             raise AttributeError(f"Unable to use HTTP method: {method}")
-
+        
         get_raw_response = kwargs.pop("get_raw_response", False)
 
         await self.logger.debug(f"Making HTTP {method.upper()} request to {url}")
@@ -925,7 +925,7 @@ class BasementBot(commands.Bot):
                     if response_object
                     else munch.Munch()
                 )
-                response["status_code"] = getattr(response_object, "status_code", None)
+                response["status_code"] = getattr(response_object, "status", None)
 
         except Exception as exception:
             await self.logger.error(f"HTTP {method} call", exception=exception)

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -28,6 +28,7 @@ main:
         news:
         wolfram:
         open_weather:
+        github:
     logging:
         queue_enabled: True
         block_discord_send: False
@@ -38,3 +39,6 @@ main:
 
 # Special things
 special:
+    github:
+        username:
+        repo:


### PR DESCRIPTION
Fixes #335 

Added issue command to the admin cog. This includes aliases 'ish', 'botish', and 'botissue'. 
Syntax is `.issue "[title]" "[description]"`
Fixed issue with status code not being set. Needed to get the 'status' attribute from the response rather than the 'status_code' attribute. 
Added 'github' under the main/api_keys in the config file for the Github OAuth token and 'github' to the special section with 'username' for the github username and 'repo' for the repo the issues will be added to under it.